### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -6,7 +6,6 @@ name: "build"
 
 on:
   push:  # We run tests on non-tagged pushes to main
-    tags: ''
     branches: main
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,61 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/commit.yaml
+---
+name: "release"
+
+on:
+  push:
+    tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
+  # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
+  # For example, you can try to build a branch without raising a pull request.
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@v2
+
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,8 @@ archives:
         format: zip
 release:
   draft: true
+changelog:
+  skip: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ clean: ## Ensure a clean build
 .PHONY: snapshot
 snapshot:
 	@go run $(goreleaser) build --snapshot --rm-dist
+
+.PHONY: release
+release:
+	@go run $(goreleaser) release --rm-dist


### PR DESCRIPTION
This adds a workflow that runs on tag that pushes artifacts to its release. 

https://github.com/anuraaga/http-wasm-tck/releases/tag/untagged-b003bca675bfae23e274

https://github.com/anuraaga/http-wasm-tck/actions/runs/4443203728/jobs/7800237619
(there seems to be something wrong with my ghcr permissions for the fork that happens on snapshot as well,  
https://github.com/anuraaga/http-wasm-tck/actions/runs/4443237654 but this repo looks like it should be ok)